### PR TITLE
[FIX] Convert Sentry shutdown_timeout config value to int

### DIFF
--- a/sentry/const.py
+++ b/sentry/const.py
@@ -86,7 +86,7 @@ def get_sentry_options():
         SentryOption("release", DEFAULT_OPTIONS["release"], None),
         SentryOption("environment", DEFAULT_OPTIONS["environment"], None),
         SentryOption("server_name", DEFAULT_OPTIONS["server_name"], None),
-        SentryOption("shutdown_timeout", DEFAULT_OPTIONS["shutdown_timeout"], None),
+        SentryOption("shutdown_timeout", DEFAULT_OPTIONS["shutdown_timeout"], to_int_if_defined),
         SentryOption("integrations", DEFAULT_OPTIONS["integrations"], None),
         SentryOption(
             "in_app_include", DEFAULT_OPTIONS["in_app_include"], split_multiple


### PR DESCRIPTION
When `sentry_shutdown_timeout` is set in Odoo config the value is treated as string. This causes the following error when a worker quits (e.g. it has reached the soft memory limit):

```
2023-12-09 00:55:08,879 32701 INFO odoo odoo.service.server: Worker (32701) virtual memory limit (5601132544) reached.
2023-12-09 00:55:12,880 32701 INFO odoo odoo.service.server: Worker (32701) exiting. request_count: 713, registry count: 1.
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/sentry_sdk/integrations/atexit.py", line 62, in _shutdown
    client.close(callback=integration.callback)
  File "/usr/local/lib/python3.6/site-packages/sentry_sdk/client.py", line 572, in close
    self.flush(timeout=timeout, callback=callback)
  File "/usr/local/lib/python3.6/site-packages/sentry_sdk/client.py", line 594, in flush
    self.transport.flush(timeout=timeout, callback=callback)
  File "/usr/local/lib/python3.6/site-packages/sentry_sdk/transport.py", line 491, in flush
    if timeout > 0:
TypeError: '>' not supported between instances of 'str' and 'int'
2023-12-09 00:55:15,882 32280 INFO odoo odoo.service.server: Worker WorkerHTTP (32280) alive
```

It does not seem to have any actual impact on Odoo if it was set to 0, however it would cause a problem with a higher value and instead quit immediately.

Using the existing `to_int_if_defined` function for the `shutdown_timeout` option fixes the issue.